### PR TITLE
Implement Single Chapter Downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,25 @@ CLI options:
 
 # create all directories/files in English
 # defaults to ar - [ISO 639-1 language code]
-./qurandw en 
+./qurandw --locale en 
 
 # specify a download directory
 # note that a subdirectory will be created for the reciter
 # defaults to current work directory
-./qurandw en ./downloads 
+./qurandw --output ./downloads 
 
 # download small chapters first (Quran in reverse order)
 # defaults to false
-./qurandw en ./downloads true
+./qurandw --reverse true
 
 # download in batches of 20, defaults to 10
-./qurandw en ./downloads true 20
+./qurandw --batches 20
+
+# download chapter by id (downloads all chapters if the id is invalid)
+./qurandw --chapterid 1
+
+# download chapter by name
+./qurandw --chapter Al-Fatihah
 
 ```
 

--- a/api/api.go
+++ b/api/api.go
@@ -60,7 +60,7 @@ func GetAudioFilesOfRecitation(id int, languageCode string) ([]AudioFile, error)
 	return audioFileResponse.AudioFiles, nil
 }
 
-func GetChapters(languageCode string) ([]Chapter, error) {
+func GetAllChapters(languageCode string) ([]Chapter, error) {
 	var chapterResponse *ChapterResponse
 
 	response, err := utils.GetRequest(getChaptersUrl(), map[string]string{
@@ -78,4 +78,51 @@ func GetChapters(languageCode string) ([]Chapter, error) {
 	}
 
 	return chapterResponse.Chapters, nil
+}
+
+func GetChapterByName(languageCode, chapterName string) (*Chapter, error) {
+	var chapterResponse *ChapterResponse
+
+	response, err := utils.GetRequest(getChaptersUrl(), map[string]string{
+		"language": languageCode,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.NewDecoder(response.Body).Decode(&chapterResponse)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, chapter := range chapterResponse.Chapters {
+		if chapter.NameSimple == chapterName {
+			return &chapter, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Chapter %s not found", chapterName)
+}
+
+func GetChapterById(languageCode string, chapterId int) (*Chapter, error) {
+
+	var chapterResponse SingleChapterResponse
+
+	response, err := utils.GetRequest(fmt.Sprintf("%s/%d", getChaptersUrl(), chapterId), map[string]string{
+		"language": languageCode,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.NewDecoder(response.Body).Decode(&chapterResponse)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &chapterResponse.Chapter, nil
 }

--- a/api/types.go
+++ b/api/types.go
@@ -47,3 +47,7 @@ type Chapter struct {
 type ChapterResponse struct {
 	Chapters []Chapter `json:"chapters"`
 }
+
+type SingleChapterResponse struct {
+	Chapter Chapter `json:"chapter"`
+}

--- a/app.go
+++ b/app.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	locale := flag.String("locale", "ar", "--locale <language>")
 	concurrentDownloads := flag.Int("batches", 10, "--batches <amount>")
-	reverseOrder := flag.Bool("reverse", false, "--reverse <true/flase>")
+	reverseOrder := flag.Bool("reverse", false, "--reverse <true/false>")
 	defaultDir, err := os.Getwd()
 	outputDir := flag.String("output", defaultDir, "--output dir/to/write/into")
 	singleChapterName := flag.String("chapter", "", "--chapter <name>")

--- a/app.go
+++ b/app.go
@@ -22,8 +22,6 @@ func main() {
 	singleChapterId := flag.Int("chapterid", -1, "--chapterid <id>")
 	flag.Parse()
 
-	fmt.Println("chapter", *singleChapterName, "chapterid", *singleChapterId)
-
 	if err != nil {
 		log.Fatalf(err.Error())
 	}

--- a/app.go
+++ b/app.go
@@ -13,24 +13,31 @@ import (
 )
 
 func main() {
-	locale := flag.String("locale", "ar", "--locale <language>")
-	concurrentDownloads := flag.Int("batches", 10, "--batches <amount>")
-	reverseOrder := flag.Bool("reverse", false, "--reverse <true/false>")
+	var locale string
+	var concurrentDownloads int
+	var reverseOrder bool
+	var outputDir string
+	var singleChapterName string
+	var singleChapterId int
+
+	flag.StringVar(&locale, "locale", "ar", "--locale <language>")
+	flag.IntVar(&concurrentDownloads, "batches", 10, "--batches <amount>")
+	flag.BoolVar(&reverseOrder, "reverse", false, "--reverse <true/false>")
 	defaultDir, err := os.Getwd()
-	outputDir := flag.String("output", defaultDir, "--output dir/to/write/into")
-	singleChapterName := flag.String("chapter", "", "--chapter <name>")
-	singleChapterId := flag.Int("chapterid", -1, "--chapterid <id>")
+	flag.StringVar(&outputDir, "output", defaultDir, "--output dir/to/write/into")
+	flag.StringVar(&singleChapterName, "chapter", "", "--chapter <name>")
+	flag.IntVar(&singleChapterId, "chapterid", -1, "--chapterid <id>")
 	flag.Parse()
 
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
 
-	if len(*locale) > 2 {
-		log.Fatalf("invalid language code %s", *locale)
+	if len(locale) > 2 {
+		log.Fatalf("invalid language code %s", locale)
 	}
 
-	recitations, err := api.GetRecitations(*locale)
+	recitations, err := api.GetRecitations(locale)
 
 	if err != nil {
 		log.Fatalf(err.Error())
@@ -65,7 +72,7 @@ func main() {
 		break
 	}
 
-	audioFiles, err := api.GetAudioFilesOfRecitation(userInputRecitationId, *locale)
+	audioFiles, err := api.GetAudioFilesOfRecitation(userInputRecitationId, locale)
 
 	if err != nil {
 		print(err.Error())
@@ -74,7 +81,7 @@ func main() {
 		)
 	}
 
-	if *reverseOrder {
+	if reverseOrder {
 		slices.SortStableFunc(audioFiles, func(i, j api.AudioFile) int {
 			return -1
 		})
@@ -82,18 +89,18 @@ func main() {
 
 	var chapters []api.Chapter
 
-	if len(*singleChapterName) > 0 {
+	if len(singleChapterName) > 0 {
 		var chapter *api.Chapter
-		chapter, err = api.GetChapterByName(*locale, *singleChapterName)
+		chapter, err = api.GetChapterByName(locale, singleChapterName)
 		if err != nil {
 			panic(err)
 		}
 
 		tempList := [1]api.Chapter{*chapter}
 		chapters = tempList[:]
-	} else if *singleChapterId > 0 && *singleChapterId <= 114 { // There are 114 chapters in the Quran
+	} else if singleChapterId > 0 && singleChapterId <= 114 { // There are 114 chapters in the Quran
 		var chapter *api.Chapter = &api.Chapter{}
-		chapter, err = api.GetChapterById(*locale, *singleChapterId)
+		chapter, err = api.GetChapterById(locale, singleChapterId)
 		if err != nil {
 			panic(err)
 		}
@@ -101,7 +108,7 @@ func main() {
 		tempList := [1]api.Chapter{*chapter}
 		chapters = tempList[:]
 	} else {
-		chapters, err = api.GetAllChapters(*locale)
+		chapters, err = api.GetAllChapters(locale)
 		if err != nil {
 			panic(err)
 		}
@@ -123,10 +130,10 @@ func main() {
 
 		fileName := fmt.Sprintf(
 			"%s.%s",
-			api.GetLocalChapterName(chapter, *locale),
+			api.GetLocalChapterName(chapter, locale),
 			audioFile.Format,
 		)
-		filePath := path.Join(*outputDir, recitation.TranslatedName.Name, fileName)
+		filePath := path.Join(outputDir, recitation.TranslatedName.Name, fileName)
 
 		err := os.MkdirAll(path.Dir(filePath), os.ModePerm)
 
@@ -153,11 +160,11 @@ func main() {
 		}(i, audioFile)
 
 		// wait for the concurrentDownloads number to download, then proceed
-		if i%*concurrentDownloads == 0 {
+		if i%concurrentDownloads == 0 {
 			wg.Wait()
 		}
 	}
 
 	wg.Wait()
-	fmt.Printf("Downloaded in %s", path.Join(*outputDir, recitation.ReciterName))
+	fmt.Printf("Downloaded in %s", path.Join(outputDir, recitation.ReciterName))
 }


### PR DESCRIPTION
This PR first migrates the command-line arguments to be specified using flags leveraging the _flag_ library in golang as I found this to be more appropriate and user-friendly. Moreover, users can download specific chapters by their IDs using the _--chapterid_ flag, and by their names using the _--chapter_ flag. 